### PR TITLE
Fix symfony 5 BC deprecation alert on TreeBuilder

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,12 +17,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('eschmar_css_inliner');
-
-        // Here you should define the parameters that are allowed to
-        // configure your bundle. See the documentation linked above for
-        // more information on that topic.
+        $treeBuilder = new TreeBuilder('eschmar_css_inliner');
+        // BC layer for symfony/config 4.1 and older
+        if (! \method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->root('eschmar_css_inliner');
+        } else {
+            $rootNode = $treeBuilder->getRootNode();
+        }
 
         return $treeBuilder;
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -5,11 +5,6 @@ namespace Eschmar\CssInlinerBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-/**
- * This is the class that validates and merges configuration from your app/config files
- *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
- */
 class Configuration implements ConfigurationInterface
 {
     /**


### PR DESCRIPTION
fix symfony v5.*  breaking change on TreeBuilder::root()